### PR TITLE
setDescriptionに長い文字列を入れられないのでsubstringする

### DIFF
--- a/src/util.ts
+++ b/src/util.ts
@@ -105,7 +105,7 @@ export class OcrResutls {
   applyAll() {
     for (const res of this.results) {
       const file = DriveApp.getFileById(res.id)
-      file.setDescription(res.text)
+      file.setDescription(res.text.substring(0, 400))
     }
   }
 }


### PR DESCRIPTION
setDescriptionで大きな文字数のtextを入れるとエラーになるので、適当な文字数にsubstringするように変更しました
![スクリーンショット 2024-01-02 15 58 13](https://github.com/hankei6km/gas-gocr2notion/assets/1964200/02f050f7-5791-457b-97ea-e3ed488aef98)
