### PR TITLE
fix!: Correct typos from 'transfomer' to 'transformer'

### DIFF
--- a/src/gocr2notion.ts
+++ b/src/gocr2notion.ts
@@ -5,7 +5,7 @@ import {
 import { createPage, retriveDatabase } from './notion.js'
 import {
   genCreatePageParameters,
-  thumbParamTeransFormer as _thumbParamTeransFormer
+  thumbParamTransformer as _thumbParamTransformer
 } from './params.js'
 import { normalizeItems, OcrResutls, pickScanFiles } from './util.js'
 
@@ -13,7 +13,7 @@ export namespace GocrToNotion {
   export type FilterMimeTypeTransformerOpts = {
     ignoreTypes: string[]
   }
-  export type FileTransfomer = (
+  export type FileTransformer = (
     ite: Generator<[FileItem, GoogleAppsScript.Drive.Schema.File]>
   ) => Generator<[FileItem, GoogleAppsScript.Drive.Schema.File]>
 
@@ -30,7 +30,7 @@ export namespace GocrToNotion {
     param: UpdatePageParameters
   }
   export type ParamsCmd = ParamsCmdCreate | ParamsCmdUpdate | ParamsCmdDelete
-  export type ParamTransfomer = (
+  export type ParamTransformer = (
     ite: Generator<[ParamsCmd, FileItem, GoogleAppsScript.Drive.Schema.File]>
   ) => Generator<[ParamsCmd, FileItem, GoogleAppsScript.Drive.Schema.File]>
 
@@ -42,11 +42,23 @@ export namespace GocrToNotion {
     removeOcrFile?: boolean
   }
 
+  /**
+   * Options for file items processing.
+   * 
+   * @property database_id - The ID of the database.
+   * @property ocrOpts - An array of OCR options.
+   * @property fileTransformers - An optional array of file transformers.
+   * @property paramTransformers - An optional array of parameter transformers.
+   * @property fileTransfomers - (Deprecated) A misspelled field name kept for backward compatibility.
+   * @property paramTransfomers - (Deprecated) A misspelled field name kept for backward compatibility.
+   */
   export type FileItemsOpts = {
     database_id: string
     ocrOpts: OcrOpts[]
-    fileTransfomers?: FileTransfomer[]
-    paramTransfomers?: ParamTransfomer[]
+    fileTransformers?: FileTransformer[]
+    paramTransformers?: ParamTransformer[]
+    fileTransfomers?: FileTransformer[]
+    paramTransfomers?: ParamTransformer[]
   }
 
   export type FileItem = {

--- a/src/util.ts
+++ b/src/util.ts
@@ -112,7 +112,7 @@ export class OcrResutls {
 
 export function getOcrFileTransformer(
   opts: GocrToNotion.FileItemsOpts
-): GocrToNotion.FileTransfomer {
+): GocrToNotion.FileTransformer {
   return function* ocrFileTransformer(ite) {
     for (const [item, file] of ite) {
       // この時点でファイルのフィルタリングは行われているが、

--- a/test/gocr2notion.spec.ts
+++ b/test/gocr2notion.spec.ts
@@ -89,24 +89,24 @@ jest.unstable_mockModule('../src/notion.js', () => {
 
 jest.unstable_mockModule('../src/params.js', () => {
   const mockGenCreatePageParameters = jest.fn()
-  const mockThumbParamTeransFormer = jest.fn()
+  const mockThumbParamTransformer = jest.fn()
   const reset = (items: any[]) => {
     mockGenCreatePageParameters.mockReset().mockImplementation(function* () {
       for (const i of items) {
         yield i
       }
     })
-    mockThumbParamTeransFormer.mockReset()
+    mockThumbParamTransformer.mockReset()
   }
 
   reset([])
   return {
     genCreatePageParameters: mockGenCreatePageParameters,
-    thumbParamTeransFormer: mockThumbParamTeransFormer,
+    thumbParamTransformer: mockThumbParamTransformer,
     _reset: reset,
     _getMocks: () => ({
       mockGenCreatePageParameters,
-      mockThumbParamTeransFormer
+      mockThumbParamTransformer
     })
   }
 })
@@ -121,7 +121,7 @@ const {
   mockSortedItems,
   mockSortedItemsMethods
 } = (mockNotion as any)._getMocks()
-const { mockGenCreatePageParameters, mockThumbParamTeransFormer } = (
+const { mockGenCreatePageParameters, mockThumbParamTransformer } = (
   mockParams as any
 )._getMocks()
 const { GocrToNotion: GrecentToNotion } = await import('../src/gocr2notion.js')


### PR DESCRIPTION
The misspelled field names used in external options are kept for backward
compatibility but marked as deprecated.
